### PR TITLE
#210/bug-udefinded-after-quit-settings-and-block-hof-button-for-time-to-time

### DIFF
--- a/src/app/view/view.js
+++ b/src/app/view/view.js
@@ -90,7 +90,9 @@ class View {
   }
 
   hideSettings() {
-    this.showViewsForChosenMode();
+    this.showViewsForChosenMode(window.app.model.gameMode);
+    window.app.bindInitialHofAndPlay();
+    this.toggleRulesHof = 'hall of fame';
   }
 
   toggleSettingsView = () => {
@@ -109,7 +111,6 @@ class View {
   }
 
   renderModal(gameData) {
-    console.log('wchodzisz?');
     this.render('.modal', ModalWindow(gameData));
     const modal = document.querySelector('.modal');
     modal.classList.remove('modal__hidden');


### PR DESCRIPTION
-added needed argument to function showViewForChosenMode() in hideSettings()

-added binding HOF button when rendered after go out from settings
-added changing of toggleHOF flag when  rendered after go out from settings to initial value "hall-of-fame"
-removed console.log